### PR TITLE
Fix service manager crash

### DIFF
--- a/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/fragment/AudioRecorderFragment.java
+++ b/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/fragment/AudioRecorderFragment.java
@@ -139,6 +139,16 @@ public class AudioRecorderFragment extends DialogFragment
     }
 
     @Override
+    public void onServiceStart() {
+        // Purposely empty.
+    }
+
+    @Override
+    public void onServiceFailedToStart(String processName, int importance) {
+        // Purposely empty.
+    }
+
+    @Override
     public void onStartRecorder() {
         Activity activity = getActivity();
         if (activity != null) {

--- a/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/manager/ServiceManager.java
+++ b/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/manager/ServiceManager.java
@@ -48,6 +48,13 @@ public class ServiceManager implements ServiceConnection {
                 // Only start the service if we are actually in the foreground.
                 // https://issuetracker.google.com/issues/110237673
                 startService();
+            } else {
+                if (mStateListener != null) {
+                    mStateListener.onServiceFailedToStart(
+                            runningAppProcesses.get(0).processName,
+                            importance
+                    );
+                }
             }
         }
     }
@@ -61,6 +68,9 @@ public class ServiceManager implements ServiceConnection {
     }
 
     protected void startService() {
+        if (mStateListener != null) {
+            mStateListener.onServiceStart();
+        }
         mActivity.startService(new Intent(mActivity, mServiceClass));
     }
 
@@ -133,5 +143,9 @@ public class ServiceManager implements ServiceConnection {
         void onServiceUnbind(IBinder binder);
 
         void onServiceStop();
+
+        void onServiceStart();
+
+        void onServiceFailedToStart(String processName, int importance);
     }
 }

--- a/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/manager/ServiceManager.java
+++ b/AudioPlayerRecorderLibrary/src/main/java/com/heavyplayer/audioplayerrecorder/service/manager/ServiceManager.java
@@ -1,8 +1,7 @@
 package com.heavyplayer.audioplayerrecorder.service.manager;
 
-import com.heavyplayer.audioplayerrecorder.BuildConfig;
-
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.app.Service;
 import android.content.ComponentName;
 import android.content.Context;
@@ -10,6 +9,10 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 import android.util.Log;
+
+import com.heavyplayer.audioplayerrecorder.BuildConfig;
+
+import java.util.List;
 
 public class ServiceManager implements ServiceConnection {
     private IBinder mBinder;
@@ -37,9 +40,16 @@ public class ServiceManager implements ServiceConnection {
     protected void onActivateService() {
         bindService();
 
-        // Ensure service keeps running until we explicitly stop it,
-        // which is always except when configuration changes occur.
-        startService();
+        ActivityManager activityManager = (ActivityManager) mActivity.getSystemService(Context.ACTIVITY_SERVICE);
+        List<ActivityManager.RunningAppProcessInfo> runningAppProcesses = activityManager.getRunningAppProcesses();
+        if (runningAppProcesses != null) {
+            int importance = runningAppProcesses.get(0).importance;
+            if (importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+                // Only start the service if we are actually in the foreground.
+                // https://issuetracker.google.com/issues/110237673
+                startService();
+            }
+        }
     }
 
     protected void onDeactivateService(boolean stopService) {

--- a/AudioPlayerRecorderSamples/src/main/java/com/heavyplayer/audioplayerrecorder/sample/activity/PlayerActivity.java
+++ b/AudioPlayerRecorderSamples/src/main/java/com/heavyplayer/audioplayerrecorder/sample/activity/PlayerActivity.java
@@ -47,6 +47,14 @@ public class PlayerActivity extends RecorderActivity {
             @Override
             public void onServiceStop() {
             }
+
+            @Override
+            public void onServiceStart() {
+            }
+
+            @Override
+            public void onServiceFailedToStart(String processName, int importance) {
+            }
         });
     }
 


### PR DESCRIPTION
Potentially fixes crash: https://console.firebase.google.com/u/0/project/td-project-01/crashlytics/app/android:com.todoist/issues/5c94bfaef8b88c29631d145f?time=last-ninety-days&sessionEventKey=661EFB9F0356000131FD3657D1CE98D6_1937057838887752195

Not reproducible, but I suspect the flow is something like this:

- App not running in background
- User receives notification about a new comment
- User taps notification to deep link into item details > comment list
- App crashes

According to [this issue](https://issuetracker.google.com/issues/110237673), the activity might not be "fully awake" so they'll be paused immediately and then resumed. 

> Applications can get the process state in Activity.onResume() by calling ActivityManager.getRunningAppProcesses() and avoid starting Service if the importance level is lower than ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND. If the device hasn’t fully awake, activities would be paused immediately and eventually be resumed again after its fully awake.

I've added logs to debug this and I can see that when you go through this flow, the service is started, paused, and started again, although in my testing the app does reach the correct foreground state (`importance = 100`) so this PR is still a guess about a fix.